### PR TITLE
Add interface for CSSBuilder injecting directly. It is the necessary …

### DIFF
--- a/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
+++ b/kotlin-styled/src/main/kotlin/styled/StyledComponents.kt
@@ -160,6 +160,10 @@ private object GlobalStyles {
     }
 }
 
+fun injectGlobal(css: CSSBuilder) {
+    injectGlobal(css.toString())
+}
+
 /**
  * @deprecated Use [createGlobalStyle] instead
  */


### PR DESCRIPTION
…abstraction, because the string can not contain all the necessary information for injection